### PR TITLE
gnutls: update to version 3.6.15 (security fix)

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
-PKG_VERSION:=3.6.14
+PKG_VERSION:=3.6.15
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6
-PKG_HASH:=5630751adec7025b8ef955af4d141d00d252a985769f51b4059e5affa3d39d63
+PKG_HASH:=0ea8c3283de8d8335d7ae338ef27c53a916f15f382753b174c18b45ffd481558
 #PKG_FIXUP:=autoreconf gettext-version
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Fixes:
CVE-2020-24659

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
